### PR TITLE
Fix lint errors

### DIFF
--- a/fsspec_union/tests/test_all.py
+++ b/fsspec_union/tests/test_all.py
@@ -1,4 +1,4 @@
-from fsspec_union import *  # noqa
+from fsspec_union import *
 
 
 def test_all():


### PR DESCRIPTION
Updates code for the latest Ruff diagnostics without changing lint configuration. `make lint` passes.